### PR TITLE
Fixed crc32 calculation overflow bug

### DIFF
--- a/src/drivers/payload_uart/payload_uart.c
+++ b/src/drivers/payload_uart/payload_uart.c
@@ -57,7 +57,8 @@ static void uart_rx_callback()
 // (not using fast version because we want small binary size)
 unsigned int crc32(const uint8_t *message, uint16_t len)
 {
-    size_t i, j;
+    size_t i;
+    int j;
     unsigned int byte, crc, mask;
 
     i = 0;

--- a/src/drivers/payload_uart/payload_uart.c
+++ b/src/drivers/payload_uart/payload_uart.c
@@ -58,7 +58,6 @@ static void uart_rx_callback()
 unsigned int crc32(const uint8_t *message, uint16_t len)
 {
     size_t i;
-    int j;
     unsigned int byte, crc, mask;
 
     i = 0;
@@ -67,7 +66,7 @@ unsigned int crc32(const uint8_t *message, uint16_t len)
     {
         byte = message[i]; // Get next byte.
         crc = crc ^ byte;
-        for (j = 7; j >= 0; j--)
+        for (int j = 0; j < 8; j++)
         { // Do eight times.
             mask = -(crc & 1);
             crc = (crc >> 1) ^ (0xEDB88320 & mask);


### PR DESCRIPTION
Bug:
When calculating the crc32 for the payload, the for loop induces a overflow which results in an infinite loop.

Fix: 
Cast for loop variable as an int rather than a size_t which is unsigned.