### PR TITLE
Added script for SWD loading of samwise binary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,9 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # Only initialize Pico SDK for non-test builds
 if(NOT BUILD_TESTS)
+  # Set PICO_SDK_PATH to use local submodule before pico-vscode.cmake
+  set(PICO_SDK_PATH ${CMAKE_CURRENT_LIST_DIR}/pico-sdk CACHE PATH "Path to the Pico SDK" FORCE)
+
   # == DO NOT EDIT THE FOLLOWING LINES for the Raspberry Pi Pico VS Code Extension to work ==
   if(WIN32)
       set(USERHOME $ENV{USERPROFILE})
@@ -60,6 +63,7 @@ if(NOT BUILD_TESTS)
   set(sdkVersion 2.0.0)
   set(toolchainVersion 13_2_Rel1)
   set(picotoolVersion 2.0.0)
+  # Note: pico-vscode.cmake sets PICO_SDK_PATH, but we override it above to use local submodule
   include(${USERHOME}/.pico-sdk/cmake/pico-vscode.cmake)
   # ====================================================================================
 

--- a/scripts/swd_load.sh
+++ b/scripts/swd_load.sh
@@ -1,0 +1,6 @@
+sudo ~/.pico-sdk/openocd/0.12.0+dev/openocd \
+    -s ~/.pico-sdk/openocd/0.12.0+dev/scripts \
+    -f interface/cmsis-dap.cfg \
+    -f target/rp2350.cfg \
+    -c "adapter speed 5000" \
+    -c "program ../build/src/samwise.elf verify reset exit"


### PR DESCRIPTION
Tinkered around with the pi debug probe today. Getting SWD to flash a binary requires using the openocd tool packaged with pico-sdk (when installed from VSCode). See `swd_load.sh` for the instructions required. Note also the change in pointing to a .elf instead of .uf2 (like for flashing with picotool)

Tiny change to setting PICO_SDK_PATH to the one included in this repo (pins it to using v2.1.0)