### PR TITLE
Made ground station code compatible with rpi pins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 **/.vite
 **/.DS_Store
 **/.vite
+**/env
 .vscode
 build*

--- a/ground_station/requirements.txt
+++ b/ground_station/requirements.txt
@@ -1,0 +1,3 @@
+adafruit-circuitpython-rfm9x
+adafruit-circuitpython-hashlib
+circuitpython-hmac


### PR DESCRIPTION
RPI detection is the fall-through from PICO2 & FEATHER M4.

Import default python libs when we don't have adafruit-circuitpython libs (on Raspberry Pi).

Raspberry Pi also doesn't have a default LED, so gate led operations behind a `LED_PIN is not None` conditional.