### PR TITLE
Ready for vibe test V5

### DIFF
--- a/ground_station/radio_initialization.py
+++ b/ground_station/radio_initialization.py
@@ -45,8 +45,8 @@ def get_board_pins(board_type):
             "MOSI": board.MOSI,  # Usually D23
             "MISO": board.MISO,  # Usually D22
             "SCK": board.SCK,  # Usually D24
-            "CS": board.A5,  # Analog pin 5
-            "RESET": board.D5,  # Digital pin 5
+            "CS": board.D10,  # Digital pin 10
+            "RESET": board.D11,  # Digital pin 11
             "LED": board.D13,  # Built-in LED
         }
     elif board_type == "RPI":

--- a/src/states/running/running_state.c
+++ b/src/states/running/running_state.c
@@ -31,11 +31,11 @@ sched_state_t running_state = {
     .task_list = {&print_task, &blink_task, &hardware_test_task},
     .get_next_state = &running_get_next_state};
 #else
-sched_state_t running_state = {
-    .name = "running",
-    .id = STATE_RUNNING,
-    .num_tasks = 8,
-    .task_list = {&print_task, &watchdog_task, &beacon_task, &adcs_task,
-                  &payload_task, &telemetry_task, &radio_task, &command_task},
-    .get_next_state = &running_get_next_state};
+sched_state_t running_state = {.name = "running",
+                               .id = STATE_RUNNING,
+                               .num_tasks = 6,
+                               .task_list = {&print_task, &watchdog_task,
+                                             &beacon_task, &telemetry_task,
+                                             &radio_task, &command_task},
+                               .get_next_state = &running_get_next_state};
 #endif

--- a/src/tasks/beacon/beacon_task.c
+++ b/src/tasks/beacon/beacon_task.c
@@ -160,7 +160,7 @@ void beacon_task_dispatch(slate_t *slate)
 }
 
 sched_task_t beacon_task = {.name = "beacon",
-                            .dispatch_period_ms = 60000,
+                            .dispatch_period_ms = 5000,
                             .task_init = &beacon_task_init,
                             .task_dispatch = &beacon_task_dispatch,
                             /* Set to an actual value on init */


### PR DESCRIPTION
1. Fix pinout for Feather M4
2. Remove adcs_task and payload_task from vibe test
3. Increase beacon frequency to once every 5 seconds

Tested that it receives burn_wire_state manual override command from latest ground_station software. And ground_station (at least on the Feather M4) receives packets (albeit only once every 15seconds apparently...)